### PR TITLE
Estrapola il comune fuori dal campo indirizzo

### DIFF
--- a/bar-noslot.csv
+++ b/bar-noslot.csv
@@ -1,14 +1,14 @@
-RAGSOC,INDIRIZZO,ID Google,ID Facebook
-Bar Centrale,Piazza Conciliazione - Desio,,
-CAFFÈ VERGNANO 1882,Corso Italia  49 20832 Desio MB,,
-Caffettiamo snc,Via Portichetto  16  Desio,ChIJ-0rGpyK8hkcRuE3QWjmvPRc,912863432136676
-Elisir Cafè,Via Giuseppe Garibaldi 157 Desio,,1517590881838289
-Elite Cafè,Via Olmetto 10 20832 Desio,,
-GELATERIA I DELFINI,Via Pozzo Antico  116  Desio,ChIJ75D0FR-8hkcRZuimx3FRiPk,474584832729491
-La piazzetta,Corso italia 79 Desio,,288253537950416    
-Madam Café,Via per Cesano Maderno  148 20832 Desio MB,ChIJ66y5XMu9hkcRnyq1gLUvl0c,
-MOMA CAFE DESIO,VIA MATTEOTTI 80 ANG VIA MILANO Desio,,1557995974464760
-New Life Cafe', Via De Gasperi 13 Desio,,1525956497662048
-Officina del Caffè,Via Garibaldi 99 Desio,,265273720298363    
-Pan&cafe,Corso Italia  13  Desio,ChIJUaujnD68hkcRnkW7JVBLnoU,172517439432668
-Torrefazione Brasilia,Via Giacomo Matteotti  8 Desio MB,,718707681542991
+Comune,CAP,Provincia,RAGSOC,INDIRIZZO,ID Google,ID Facebook
+Desio,20832,MB,Bar Centrale,Piazza Conciliazione,,
+Desio,20832,MB,CAFFÈ VERGNANO 1882,Corso Italia 49,,
+Desio,20832,MB,Caffettiamo snc,Via Portichetto 16,ChIJ-0rGpyK8hkcRuE3QWjmvPRc,912863432136676
+Desio,20832,MB,Elisir Cafè,Via Giuseppe Garibaldi 157,,1517590881838289
+Desio,20832,MB,Elite Cafè,Via Olmetto 10,,
+Desio,20832,MB,GELATERIA I DELFINI,Via Pozzo Antico  116,ChIJ75D0FR-8hkcRZuimx3FRiPk,474584832729491
+Desio,20832,MB,La piazzetta,Corso italia 79,,288253537950416
+Desio,20832,MB,Madam Café,Via per Cesano Maderno  148,ChIJ66y5XMu9hkcRnyq1gLUvl0c,
+Desio,20832,MB,MOMA CAFE DESIO,VIA MATTEOTTI 80 ANG VIA MILANO,,1557995974464760
+Desio,20832,MB,New Life Cafe', Via De Gasperi 13,,1525956497662048
+Desio,20832,MB,Officina del Caffè,Via Garibaldi 99,,265273720298363
+Desio,20832,MB,Pan&cafe,Corso Italia  13,ChIJUaujnD68hkcRnkW7JVBLnoU,172517439432668
+Desio,20832,MB,Torrefazione Brasilia,Via Giacomo Matteotti 8,,718707681542991


### PR DESCRIPTION
In questo modo il dataset è pronto per ospitare anche dati di altri comuni e comunque l'informazione sulla locazione risulta più strutturata.